### PR TITLE
Add Blazegraph jar helper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
             pkgs.awscli2
             pkgs.python310Packages.pip
             pkgs.gcc
+            pkgs.openjdk
           ];
 
           shellHook = ''source scripts/flake/shellhook.sh'';

--- a/scripts/flake/shellhook.sh
+++ b/scripts/flake/shellhook.sh
@@ -20,6 +20,8 @@ source scripts/flake/run_flyway.sh
 
 source scripts/flake/start_redis.sh
 
+source scripts/flake/start_blazegraph.sh
+
 source scripts/load_environment.sh "$AWS_PROFILE" "ctgov-compliance-web-dev"
 
 eval "$OLD_OPTS"

--- a/scripts/flake/start_blazegraph.sh
+++ b/scripts/flake/start_blazegraph.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Starts a local Blazegraph instance from a jar if not already running.
+# If the jar is missing it will be downloaded automatically.
+# Blazegraph will listen on port 9999 by default.
+
+set -euo pipefail
+
+JAR_PATH="${BLAZEGRAPH_JAR:-$PWD/blazegraph.jar}"
+PORT="${BLAZEGRAPH_PORT:-9999}"
+DOWNLOAD_URL="https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_2_1_5/blazegraph.jar"
+
+if lsof -i:"$PORT" >/dev/null 2>&1; then
+    echo "Blazegraph already running on port $PORT."
+    exit 0
+fi
+
+if [ ! -f "$JAR_PATH" ]; then
+    echo "Downloading Blazegraph jar to $JAR_PATH..."
+    curl -L -o "$JAR_PATH" "$DOWNLOAD_URL"
+fi
+
+echo "Starting Blazegraph on port $PORT..."
+java -jar "$JAR_PATH" --port "$PORT" >/dev/null 2>&1 &
+echo $! > .blazegraph.pid
+echo "Blazegraph started with PID $(cat .blazegraph.pid)"
+
+


### PR DESCRIPTION
## Summary
- run Blazegraph from a jar instead of Docker
- download the Blazegraph jar automatically
- add `openjdk` to the dev shell

## Testing
- `bash scripts/setup.sh` *(fails: requirements.txt missing)*

------
https://chatgpt.com/codex/tasks/task_e_683b4b7083d4832b96c08c3bb11e5f85