### PR TITLE
Add trial data model and mock data loader

### DIFF
--- a/.flyway/sql/V2__create_org_and_trials.sql
+++ b/.flyway/sql/V2__create_org_and_trials.sql
@@ -1,0 +1,30 @@
+CREATE TABLE organization (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE user_organization (
+    user_id INTEGER NOT NULL REFERENCES ctgov_user(id) ON DELETE CASCADE,
+    organization_id INTEGER NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+    role VARCHAR(50) DEFAULT 'clinician',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, organization_id)
+);
+
+CREATE TABLE trial (
+    id SERIAL PRIMARY KEY,
+    nct_id VARCHAR(20) NOT NULL UNIQUE,
+    organization_id INTEGER NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+    title VARCHAR(255),
+    start_date DATE,
+    completion_date DATE,
+    reporting_due_date DATE
+);
+
+CREATE TABLE trial_compliance (
+    id SERIAL PRIMARY KEY,
+    trial_id INTEGER NOT NULL REFERENCES trial(id) ON DELETE CASCADE,
+    status VARCHAR(20) NOT NULL,
+    last_checked TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ cd scripts
 
 The setup script is idempotent. It starts the containers, runs Flyway and
 Django migrations and loads mock data into Blazegraph.
+
+### Mock Data
+
+For convenience a helper script is included to load mock organizations,
+users, trials and compliance information into both PostgreSQL and Blazegraph.
+
+```bash
+python scripts/init_mock_data.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psycopg2-binary
+requests

--- a/scripts/init_mock_data.py
+++ b/scripts/init_mock_data.py
@@ -1,0 +1,92 @@
+import os
+import hashlib
+import psycopg2
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).parent))
+from populate_blazegraph import insert_mock_data
+
+
+def get_conn():
+    return psycopg2.connect(
+        host=os.environ.get('DB_HOST', 'localhost'),
+        port=os.environ.get('DB_PORT', '5464'),
+        dbname=os.environ.get('DB_NAME', 'ctgov-web'),
+        user=os.environ.get('DB_USER', 'postgres'),
+        password=os.environ.get('DB_PASSWORD', 'devpassword'),
+    )
+
+
+def hash_pwd(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def populate_postgres():
+    conn = get_conn()
+    cur = conn.cursor()
+
+    # organizations
+    cur.execute("INSERT INTO organization (name) VALUES (%s) RETURNING id", ("Acme Health",))
+    org1_id = cur.fetchone()[0]
+    cur.execute("INSERT INTO organization (name) VALUES (%s) RETURNING id", ("Beta Clinic",))
+    org2_id = cur.fetchone()[0]
+
+    # users
+    cur.execute(
+        "INSERT INTO ctgov_user (email, password_hash) VALUES (%s, %s) RETURNING id",
+        ("alice@example.com", hash_pwd("password")),
+    )
+    alice_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO ctgov_user (email, password_hash) VALUES (%s, %s) RETURNING id",
+        ("bob@example.com", hash_pwd("password")),
+    )
+    bob_id = cur.fetchone()[0]
+
+    # memberships
+    cur.execute(
+        "INSERT INTO user_organization (user_id, organization_id, role) VALUES (%s, %s, %s)",
+        (alice_id, org1_id, "clinician"),
+    )
+    cur.execute(
+        "INSERT INTO user_organization (user_id, organization_id, role) VALUES (%s, %s, %s)",
+        (bob_id, org2_id, "clinician"),
+    )
+
+    # trials
+    cur.execute(
+        "INSERT INTO trial (nct_id, organization_id, title, start_date, completion_date) "
+        "VALUES (%s, %s, %s, %s, %s) RETURNING id",
+        ("NCT00000001", org1_id, "Hypertension Study", "2022-01-01", "2023-01-01"),
+    )
+    trial1_id = cur.fetchone()[0]
+    cur.execute(
+        "INSERT INTO trial (nct_id, organization_id, title, start_date, completion_date) "
+        "VALUES (%s, %s, %s, %s, %s) RETURNING id",
+        ("NCT00000002", org2_id, "Diabetes Study", "2022-06-01", "2024-06-01"),
+    )
+    trial2_id = cur.fetchone()[0]
+
+    # compliance entries
+    cur.execute(
+        "INSERT INTO trial_compliance (trial_id, status) VALUES (%s, %s)",
+        (trial1_id, "on time"),
+    )
+    cur.execute(
+        "INSERT INTO trial_compliance (trial_id, status) VALUES (%s, %s)",
+        (trial2_id, "late"),
+    )
+
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+def main():
+    populate_postgres()
+    insert_mock_data()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create Flyway migration for organizations, trials and compliance tables
- add script to populate PostgreSQL and Blazegraph with mock data
- add Python dependency list
- document mock data helper in README

## Testing
- `python -m py_compile scripts/init_mock_data.py scripts/populate_blazegraph.py`

------
https://chatgpt.com/codex/tasks/task_e_683b53ab2300832b9a4108a97f66e1a7