### PR TITLE
Improve mobile responsiveness and page styling

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,0 +1,11 @@
+/* Custom styles for CTGov Compliance */
+
+.login-card {
+  max-width: 30rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.table-container {
+  overflow-x: auto;
+}

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -2,7 +2,8 @@
 {% block title %}Dashboard - CTGov Compliance{% endblock %}
 {% block content %}
 <h1 class="usa-heading">Your Trials</h1>
-<table class="usa-table">
+<div class="table-container">
+<table class="usa-table usa-table--striped usa-table--stacked">
   <thead>
     <tr>
       <th>NCT ID</th>
@@ -20,9 +21,11 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 
 <h2 class="usa-heading">Organization Compliance Rates</h2>
-<table class="usa-table">
+<div class="table-container">
+<table class="usa-table usa-table--striped usa-table--stacked">
   <thead>
     <tr>
       <th>Organization</th>
@@ -38,4 +41,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}CTGov Compliance{% endblock %}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uswds@3.7.0/dist/css/uswds.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/uswds@3.7.0/dist/js/uswds.min.js" defer></script>
 </head>
 <body>
@@ -18,6 +19,7 @@
   </div>
 </header>
 <main class="usa-section">
+  <div class="grid-container">
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
         <div class="usa-alert">
@@ -28,6 +30,7 @@
       {% endif %}
     {% endwith %}
     {% block content %}{% endblock %}
+  </div>
 </main>
 <footer class="usa-footer usa-footer--slim">
   <div class="grid-container">

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -1,19 +1,23 @@
 {% extends 'layout.html' %}
 {% block title %}Login - CTGov Compliance{% endblock %}
 {% block content %}
-<div class="grid-row">
-  <div class="tablet:grid-col-4">
-    <form method="post">
-      <div class="usa-form-group">
-        <label class="usa-label" for="email">Email</label>
-        <input class="usa-input" id="email" name="email" type="email" required>
+<div class="grid-row flex-justify-center">
+  <div class="grid-col-12 tablet:grid-col-6">
+    <div class="usa-card login-card">
+      <div class="usa-card__body">
+        <form method="post">
+          <div class="usa-form-group">
+            <label class="usa-label" for="email">Email</label>
+            <input class="usa-input" id="email" name="email" type="email" required>
+          </div>
+          <div class="usa-form-group">
+            <label class="usa-label" for="password">Password</label>
+            <input class="usa-input" id="password" name="password" type="password" required>
+          </div>
+          <button class="usa-button" type="submit">Login</button>
+        </form>
       </div>
-      <div class="usa-form-group">
-        <label class="usa-label" for="password">Password</label>
-        <input class="usa-input" id="password" name="password" type="password" required>
-      </div>
-      <button class="usa-button" type="submit">Login</button>
-    </form>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a local stylesheet for minor tweaks
- wrap main content in a grid-container
- style login page using a card layout
- make dashboard tables stacked and scrollable on small screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683b6c1bf6d8832bbe76a600734ec3bc