### PR TITLE
Add unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is in sys.path so 'web' can be imported
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,10 @@
+import os
+from web import create_app
+
+
+def test_create_app_registers_blueprints(monkeypatch):
+    os.environ['SECRET_KEY'] = 'test-secret'
+    app = create_app()
+    assert app.config['SECRET_KEY'] == 'test-secret'
+    assert 'auth.login' in app.view_functions
+    assert 'dashboard.index' in app.view_functions

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,17 @@
+from web import auth
+
+
+def test_user_get_returns_user(monkeypatch):
+    def fake_query(sql, params=None, fetchone=False):
+        assert fetchone
+        return {'id': 1, 'email': 'alice@example.com', 'password_hash': 'x'}
+    monkeypatch.setattr(auth, 'query', fake_query)
+    user = auth.User.get(1)
+    assert isinstance(user, auth.User)
+    assert user.id == 1
+    assert user.email == 'alice@example.com'
+
+
+def test_user_get_returns_none(monkeypatch):
+    monkeypatch.setattr(auth, 'query', lambda *a, **k: None)
+    assert auth.User.get(99) is None

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,27 @@
+from web import dashboard
+
+
+def test_get_user_trials(monkeypatch):
+    calls = {}
+    def fake_query(sql, params=None):
+        calls['sql'] = sql
+        calls['params'] = params
+        return [{'nct_id': 'NCT1'}]
+    monkeypatch.setattr(dashboard, 'query', fake_query)
+    result = dashboard.get_user_trials(2)
+    assert result == [{'nct_id': 'NCT1'}]
+    assert 'uo.user_id = %s' in calls['sql']
+    assert calls['params'] == [2]
+
+
+def test_get_org_compliance(monkeypatch):
+    calls = {}
+    def fake_query(sql, params=None):
+        calls['sql'] = sql
+        calls['params'] = params
+        return [{'name': 'Org', 'rate': 100}]
+    monkeypatch.setattr(dashboard, 'query', fake_query)
+    result = dashboard.get_org_compliance()
+    assert result == [{'name': 'Org', 'rate': 100}]
+    assert 'organization' in calls['sql'].lower()
+    assert calls['params'] is None


### PR DESCRIPTION
## Summary
- add conftest to ensure imports resolve
- test application factory blueprint registration
- test User model retrieval logic
- test dashboard query helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b9a77b834832bbcbb2bcd797a1a1c