### PR TITLE
Add CSRF protection

### DIFF
--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,12 +1,17 @@
 import os
 from flask import Flask
+from flask_wtf import CSRFProtect
 from .auth import bp as auth_bp, login_manager
 from .dashboard import bp as dashboard_bp
+
+csrf = CSRFProtect()
 
 
 def create_app():
     app = Flask(__name__)
     app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')
+
+    csrf.init_app(app)
 
     login_manager.init_app(app)
     app.register_blueprint(auth_bp)

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -6,6 +6,7 @@
     <div class="usa-card login-card">
       <div class="usa-card__body">
         <form method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <div class="usa-form-group">
             <label class="usa-label" for="email">Email</label>
             <input class="usa-input" id="email" name="email" type="email" required>


### PR DESCRIPTION
## Summary
- enable CSRF protection with Flask‑WTF
- include a CSRF token in the login form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b9aa71230832b83ae5672144bc272