### PR TITLE
Add user registration and reset flows

### DIFF
--- a/.flyway/sql/V4__create_password_reset.sql
+++ b/.flyway/sql/V4__create_password_reset.sql
@@ -1,0 +1,9 @@
+CREATE TABLE password_reset (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES ctgov_user(id) ON DELETE CASCADE,
+    token VARCHAR(64) NOT NULL UNIQUE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_password_reset_token ON password_reset(token);

--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ development server:
 ```bash
 flask run --host 0.0.0.0 --port 6513
 ```
+
+### Account Management
+
+You can create an account directly in the application and reset your password when needed.
+
+1. Visit `/register` to sign up for a new account.
+2. Use `/reset` to generate a password reset link.
+
+

--- a/web/templates/register.html
+++ b/web/templates/register.html
@@ -1,5 +1,5 @@
 {% extends 'layout.html' %}
-{% block title %}Login - CTGov Compliance{% endblock %}
+{% block title %}Register - CTGov Compliance{% endblock %}
 {% block content %}
 <div class="grid-row flex-justify-center">
   <div class="grid-col-12 tablet:grid-col-6">
@@ -14,12 +14,8 @@
             <label class="usa-label" for="password">Password</label>
             <input class="usa-input" id="password" name="password" type="password" required>
           </div>
-          <button class="usa-button" type="submit">Login</button>
+          <button class="usa-button" type="submit">Register</button>
         </form>
-        <div class="usa-form-group margin-top-1">
-          <a href="{{ url_for('auth.register') }}">Register</a> |
-          <a href="{{ url_for('auth.reset_request') }}">Forgot password?</a>
-        </div>
       </div>
     </div>
   </div>

--- a/web/templates/reset_password.html
+++ b/web/templates/reset_password.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+{% block title %}Set New Password - CTGov Compliance{% endblock %}
+{% block content %}
+<div class="grid-row flex-justify-center">
+  <div class="grid-col-12 tablet:grid-col-6">
+    <div class="usa-card login-card">
+      <div class="usa-card__body">
+        <form method="post">
+          <div class="usa-form-group">
+            <label class="usa-label" for="password">New Password</label>
+            <input class="usa-input" id="password" name="password" type="password" required>
+          </div>
+          <button class="usa-button" type="submit">Reset Password</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/web/templates/reset_request.html
+++ b/web/templates/reset_request.html
@@ -1,0 +1,19 @@
+{% extends 'layout.html' %}
+{% block title %}Reset Password - CTGov Compliance{% endblock %}
+{% block content %}
+<div class="grid-row flex-justify-center">
+  <div class="grid-col-12 tablet:grid-col-6">
+    <div class="usa-card login-card">
+      <div class="usa-card__body">
+        <form method="post">
+          <div class="usa-form-group">
+            <label class="usa-label" for="email">Email</label>
+            <input class="usa-input" id="email" name="email" type="email" required>
+          </div>
+          <button class="usa-button" type="submit">Send Reset Link</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add password reset table
- add registration and password reset pages
- implement registration and reset logic
- update navigation on the login page
- document account management in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b9ae5ad78832b9916dbbb6da2bc33