### PR TITLE
Add auto-authentication for development environment

### DIFF
--- a/DEV_ENV.md
+++ b/DEV_ENV.md
@@ -1,0 +1,142 @@
+# Development Environment Auto-Authentication
+
+## Overview
+This document tracks the implementation of automatic user authentication for development environments in the CTGov Compliance Web application.
+
+## Objective
+When `ENVIRONMENT=dev`, automatically authenticate users as a default test user without requiring manual login, while preserving normal authentication flow for other environments.
+
+## Default Test User Credentials
+- **Username**: user1@example.com
+- **Password**: password
+
+## Implementation Log
+
+### Phase 1: Environment-Based Auto-Login
+- [x] Add environment detection in app initialization
+- [x] Create auto-login middleware/before_request handler
+- [x] Define default test user configuration
+
+### Phase 2: Modify Authentication Flow
+- [x] Update User class for dev mode support
+- [x] Implement auto-authentication logic
+- [x] Add User.get_by_email() method if needed
+
+### Phase 3: Route Handling
+- [x] Implement conditional route protection
+- [x] Preserve manual auth routes functionality
+- [x] Test auto-authentication flow
+
+### Phase 4: Testing and Documentation
+- [x] Test auto-authentication behavior
+- [x] Test fallback to normal authentication
+- [x] Verify production safety
+
+## Changes Made
+
+### Files Modified
+- `web/__init__.py` - App initialization and environment detection
+  - Added `ENVIRONMENT` config from environment variable
+  - Added `before_request` handler for auto-authentication
+  - Auto-authentication logic for dev environment only
+  - Skips auth routes and already authenticated users
+  - Graceful fallback on errors
+
+- `web/auth.py` - User class and authentication logic
+  - Added `User.get_by_email()` static method
+  - Enables lookup of users by email address for auto-authentication
+
+### Environment Variables
+- `ENVIRONMENT=dev` - Enables auto-authentication mode
+
+## Testing Notes
+- Auto-authentication only works when `ENVIRONMENT=dev`
+- Normal authentication preserved for all other environments
+- Manual login/logout still functional in dev mode
+- Tested with custom test script - all functionality verified
+- Routes that skip auto-authentication: login, register, logout, reset_request, reset_password, health
+
+## Usage Instructions
+
+### To Enable Auto-Authentication
+Set the environment variable before starting the application:
+```bash
+export ENVIRONMENT=dev
+flask run --host 0.0.0.0 --port 6525
+```
+
+### To Disable Auto-Authentication
+Either unset the environment variable or set it to any other value:
+```bash
+export ENVIRONMENT=production
+# or
+unset ENVIRONMENT
+```
+
+### Default Test User
+When auto-authentication is enabled, users will be automatically logged in as:
+- **Email**: user1@example.com
+- **Password**: password (not needed for auto-login)
+
+Note: This user must exist in the database/mock data for auto-authentication to work. The user is automatically created by the `scripts/init_mock_data.py` script.
+
+## Example Usage
+
+```bash
+# 1. Set up the database with mock data (if not already done)
+python3 scripts/init_mock_data.py
+
+# 2. Enable development auto-authentication
+export ENVIRONMENT=dev
+
+# 3. Start the application
+flask run --host 0.0.0.0 --port 6525
+
+# 4. Visit any protected route - you'll be automatically logged in as user1@example.com
+# For example: http://localhost:6525/
+```
+
+The application will automatically log you in when you visit any protected route. You can still manually log out and log in as different users by visiting `/logout` and `/login`.
+
+## Implementation Details
+
+### Auto-Authentication Flow
+1. Before each request, the `auto_authenticate_dev_user()` function is called
+2. Checks if `ENVIRONMENT=dev` is set
+3. Skips auto-auth for auth-related routes and health check
+4. Skips if user is already authenticated
+5. Attempts to load `user1@example.com` from database
+6. If user found, automatically logs them in using `login_user()`
+7. Logs authentication events for debugging
+8. Gracefully falls back to normal auth on any errors
+
+### Code Changes Summary
+- **User.get_by_email()**: New static method for email-based user lookup
+- **before_request handler**: Auto-authentication middleware
+- **Environment detection**: Reads `ENVIRONMENT` variable in app config
+- **Error handling**: Graceful fallback if auto-auth fails
+
+### Compatibility with Existing Systems
+- **Mock Data Integration**: Works seamlessly with `scripts/init_mock_data.py`
+- **No Database Changes**: Uses existing user table structure
+- **Preserved Authentication**: All existing auth routes work normally
+- **Non-Intrusive**: Only adds functionality, doesn't modify existing behavior
+
+## Security Considerations
+- Auto-authentication is development-only
+- Production deployments should never use `ENVIRONMENT=dev`
+- Real authentication system remains unchanged for production
+- Auto-authentication has comprehensive error handling
+- No sensitive data logged (only email addresses for debugging)
+
+## Summary
+
+The development environment auto-authentication feature has been successfully implemented with the following key benefits:
+
+✅ **Developer Experience**: No need to manually log in during development  
+✅ **Production Safety**: Only works when `ENVIRONMENT=dev` is explicitly set  
+✅ **Backward Compatibility**: All existing authentication flows preserved  
+✅ **Error Handling**: Graceful fallback to normal authentication on failures  
+✅ **Testing Verified**: All functionality tested and working correctly  
+
+The implementation is minimal, non-intrusive, and maintains the security and functionality of the production authentication system while significantly improving the development workflow. 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,6 +1,7 @@
 import os
-from flask import Flask
+from flask import Flask, request, g
 from flask_wtf import CSRFProtect
+from flask_login import current_user, login_user
 from .auth import bp as auth_bp, login_manager
 from .routes import bp as routes_bp
 
@@ -12,6 +13,7 @@ def create_app(test_config=None):
     
     # Load default configuration
     app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev')
+    app.config['ENVIRONMENT'] = os.environ.get('ENVIRONMENT', 'production')
     
     # Override with test config if provided
     if test_config is not None:
@@ -25,5 +27,31 @@ def create_app(test_config=None):
     login_manager.init_app(app)
     app.register_blueprint(auth_bp)
     app.register_blueprint(routes_bp)
+
+    # Auto-authentication for development environment
+    @app.before_request
+    def auto_authenticate_dev_user():
+        # Only auto-authenticate in dev environment
+        if app.config.get('ENVIRONMENT') != 'dev':
+            return
+        
+        # Skip auto-auth for auth routes and health check
+        if request.endpoint in ['auth.login', 'auth.register', 'auth.logout', 'auth.reset_request', 'auth.reset_password', 'routes.health']:
+            return
+            
+        # Skip if user is already authenticated
+        if current_user.is_authenticated:
+            return
+            
+        # Auto-login as default test user
+        try:
+            from .auth import User
+            user = User.get_by_email('user1@example.com')
+            if user:
+                login_user(user)
+                app.logger.info(f"Auto-authenticated user: {user.email} (dev environment)")
+        except Exception as e:
+            # If auto-authentication fails, let normal auth flow handle it
+            app.logger.warning(f"Auto-authentication failed: {e}")
 
     return app

--- a/web/auth.py
+++ b/web/auth.py
@@ -44,6 +44,13 @@ class User(UserMixin):
             return User(row['id'], row['email'], row['password_hash'])
         return None
 
+    @staticmethod
+    def get_by_email(email):
+        row = query('SELECT id, email, password_hash FROM ctgov_user WHERE email=%s', [email], fetchone=True)
+        if row:
+            return User(row['id'], row['email'], row['password_hash'])
+        return None
+
 @login_manager.user_loader
 def load_user(user_id):
     return User.get(user_id)


### PR DESCRIPTION
- Add User.get_by_email() method for email-based user lookup
- Implement before_request handler for auto-authentication in dev mode
- Auto-authenticate as user1@example.com when ENVIRONMENT=dev
- Skip auth routes and preserve existing authentication functionality
- Add comprehensive error handling with graceful fallback
- Only works in development environment for security
- Add documentation in DEV_ENV.md with usage instructions

Resolves development workflow issue where manual login was required every time during development when database may not be working.