### PR TITLE
feat: implement SQL-based pagination with LIMIT and OFFSET

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,7 +118,7 @@ jobs:
             --port=6525
             --max-instances=2
             --cpu=1
-            --memory=1Gi
+            --memory=2Gi
             --timeout=60
             --concurrency=80
             --allow-unauthenticated

--- a/tests/test_route_helpers.py
+++ b/tests/test_route_helpers.py
@@ -30,58 +30,57 @@ class TestComplianceCounts:
             if name == 'pandas':
                 return mock_pd
             return __import__(name, *args, **kwargs)
+        
         mock_import.side_effect = side_effect
         
-        # Setup mock DataFrame
+        # Mock DataFrame and value_counts
         mock_df = MagicMock()
         mock_pd.DataFrame.return_value = mock_df
         mock_df.empty = False
         
-        # Setup mock value_counts
         mock_value_counts = MagicMock()
         mock_df.__getitem__.return_value.value_counts.return_value = mock_value_counts
-        mock_value_counts.get.side_effect = lambda status, default: {'Compliant': 5, 'Incompliant': 3}.get(status, default)
+        mock_value_counts.get.side_effect = lambda x, default=0: {'Compliant': 5, 'Incompliant': 3}.get(x, default)
         
+        # Test data
         trials = [
-            {'status': 'Compliant'},
-            {'status': 'Incompliant'},
-            {'status': 'Compliant'}
+            {'nct_id': 'NCT001', 'status': 'Compliant'},
+            {'nct_id': 'NCT002', 'status': 'Incompliant'},
+            {'nct_id': 'NCT003', 'status': 'Compliant'}
         ]
         
-        on_time_count, late_count = compliance_counts(trials)
+        result = compliance_counts(trials)
         
-        assert on_time_count == 5
-        assert late_count == 3
+        assert result == (5, 3)
         mock_pd.DataFrame.assert_called_once_with(trials)
+        mock_df.__getitem__.assert_called_once_with('status')
     
     @patch('builtins.__import__')
     def test_compliance_counts_empty_trials(self, mock_import):
-        """Test compliance_counts with empty trials."""
+        """Test compliance_counts with empty trials list."""
         # Mock pandas import
         mock_pd = MagicMock()
         def side_effect(name, *args, **kwargs):
             if name == 'pandas':
                 return mock_pd
             return __import__(name, *args, **kwargs)
+        
         mock_import.side_effect = side_effect
         
-        # Setup mock DataFrame
+        # Mock DataFrame
         mock_df = MagicMock()
         mock_pd.DataFrame.return_value = mock_df
         mock_df.empty = True
         
-        # Setup mock Series for empty case
-        mock_empty_series = MagicMock()
-        mock_pd.Series.return_value = mock_empty_series
-        mock_empty_series.get.return_value = 0
+        # Mock empty Series
+        mock_series = MagicMock()
+        mock_pd.Series.return_value = mock_series
+        mock_series.get.return_value = 0
         
-        trials = []
+        result = compliance_counts([])
         
-        on_time_count, late_count = compliance_counts(trials)
-        
-        assert on_time_count == 0
-        assert late_count == 0
-        mock_pd.DataFrame.assert_called_once_with(trials)
+        assert result == (0, 0)
+        mock_pd.DataFrame.assert_called_once_with([])
 
 
 class TestProcessIndexRequest:
@@ -89,12 +88,14 @@ class TestProcessIndexRequest:
     
     @patch('web.utils.route_helpers.compliance_counts')
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_all_trials_count')
     @patch('web.utils.route_helpers.get_all_trials')
-    def test_process_index_request(self, mock_get_all_trials, mock_paginate, mock_compliance_counts):
+    def test_process_index_request(self, mock_get_all_trials, mock_get_all_trials_count, mock_paginate, mock_compliance_counts):
         """Test processing index request."""
         # Setup mocks
         sample_trials = [{'nct_id': 'NCT001', 'status': 'Compliant'}]
-        mock_get_all_trials.return_value = sample_trials
+        mock_get_all_trials.side_effect = [sample_trials, sample_trials]  # Called twice: once for paginated, once for all
+        mock_get_all_trials_count.return_value = 100
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = sample_trials
@@ -102,8 +103,8 @@ class TestProcessIndexRequest:
         
         mock_compliance_counts.return_value = (5, 3)
         
-        # Call function
-        result = process_index_request()
+        # Call function with explicit pagination parameters
+        result = process_index_request(page=1, per_page=10)
         
         # Verify result
         expected = {
@@ -116,9 +117,14 @@ class TestProcessIndexRequest:
         }
         assert result == expected
         
-        # Verify mocks were called
-        mock_get_all_trials.assert_called_once()
-        mock_paginate.assert_called_once_with(sample_trials)
+        # Verify mocks were called correctly
+        assert mock_get_all_trials.call_count == 2
+        # First call with pagination parameters
+        mock_get_all_trials.assert_any_call(page=1, per_page=10)
+        # Second call without pagination parameters (for compliance counts)
+        mock_get_all_trials.assert_any_call()
+        mock_get_all_trials_count.assert_called_once()
+        mock_paginate.assert_called_once_with(sample_trials, total_entries=100)
         mock_compliance_counts.assert_called_once_with(sample_trials)
 
 
@@ -127,15 +133,17 @@ class TestProcessSearchRequest:
     
     @patch('web.utils.route_helpers.compliance_counts')
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.search_trials_count')
     @patch('web.utils.route_helpers.search_trials')
-    def test_process_search_request_with_params(self, mock_search_trials, mock_paginate, mock_compliance_counts):
+    def test_process_search_request_with_params(self, mock_search_trials, mock_search_trials_count, mock_paginate, mock_compliance_counts):
         """Test processing search request with parameters."""
         # Setup mocks
         search_params = {'title': 'Cancer', 'nct_id': None}
         compliance_status_list = []
         
         search_results = [{'nct_id': 'NCT001', 'status': 'Compliant'}]
-        mock_search_trials.return_value = search_results
+        mock_search_trials.side_effect = [search_results, search_results]  # Called twice
+        mock_search_trials_count.return_value = 50
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = search_results
@@ -143,8 +151,8 @@ class TestProcessSearchRequest:
         
         mock_compliance_counts.return_value = (1, 0)
         
-        # Call function
-        result = process_search_request(search_params, compliance_status_list)
+        # Call function with explicit pagination parameters
+        result = process_search_request(search_params, compliance_status_list, page=1, per_page=10)
         
         # Verify result
         expected = {
@@ -158,22 +166,27 @@ class TestProcessSearchRequest:
         }
         assert result == expected
         
-        # Verify mocks were called
-        mock_search_trials.assert_called_once_with(search_params)
-        mock_paginate.assert_called_once_with(search_results)
+        # Verify mocks were called correctly
+        assert mock_search_trials.call_count == 2
+        mock_search_trials.assert_any_call(search_params, page=1, per_page=10)
+        mock_search_trials.assert_any_call(search_params)
+        mock_search_trials_count.assert_called_once_with(search_params)
+        mock_paginate.assert_called_once_with(search_results, total_entries=50)
         mock_compliance_counts.assert_called_once_with(search_results)
-    
+
     def test_process_search_request_with_compliance_status(self):
         """Test processing search request with compliance status only."""
         search_params = {'title': None, 'nct_id': None}
         compliance_status_list = ['Compliant']
         
         with patch('web.utils.route_helpers.search_trials') as mock_search_trials, \
+             patch('web.utils.route_helpers.search_trials_count') as mock_search_trials_count, \
              patch('web.utils.route_helpers.paginate') as mock_paginate, \
              patch('web.utils.route_helpers.compliance_counts') as mock_compliance_counts:
             
             search_results = [{'nct_id': 'NCT001', 'status': 'Compliant'}]
-            mock_search_trials.return_value = search_results
+            mock_search_trials.side_effect = [search_results, search_results]
+            mock_search_trials_count.return_value = 25
             
             mock_pagination = MagicMock()
             mock_pagination.items_page = search_results
@@ -181,22 +194,36 @@ class TestProcessSearchRequest:
             
             mock_compliance_counts.return_value = (1, 0)
             
-            # Call function
-            result = process_search_request(search_params, compliance_status_list)
+            # Call function with explicit pagination parameters
+            result = process_search_request(search_params, compliance_status_list, page=1, per_page=10)
             
-            # Should perform search because compliance_status_list is not empty
-            assert result['is_search'] is True
-            mock_search_trials.assert_called_once_with(search_params)
-    
+            # Verify result
+            expected = {
+                'template': 'dashboards/home.html',
+                'trials': search_results,
+                'pagination': mock_pagination,
+                'per_page': 10,
+                'on_time_count': 1,
+                'late_count': 0,
+                'is_search': True
+            }
+            assert result == expected
+            
+            # Verify mocks were called correctly
+            assert mock_search_trials.call_count == 2
+            mock_search_trials_count.assert_called_once_with(search_params)
+            mock_paginate.assert_called_once_with(search_results, total_entries=25)
+            mock_compliance_counts.assert_called_once_with(search_results)
+
     def test_process_search_request_no_params(self):
         """Test processing search request with no parameters."""
-        search_params = {'title': None, 'nct_id': None, 'organization': None}
+        search_params = {'title': None, 'nct_id': None}
         compliance_status_list = []
         
         # Call function
-        result = process_search_request(search_params, compliance_status_list)
+        result = process_search_request(search_params, compliance_status_list, page=1, per_page=10)
         
-        # Verify result - should just return template without search
+        # Verify result
         expected = {
             'template': 'dashboards/home.html'
         }
@@ -208,14 +235,16 @@ class TestProcessOrganizationDashboardRequest:
     
     @patch('web.utils.route_helpers.compliance_counts')
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_org_trials_count')
     @patch('web.utils.route_helpers.get_org_trials')
-    def test_process_organization_dashboard_request(self, mock_get_org_trials, mock_paginate, mock_compliance_counts):
+    def test_process_organization_dashboard_request(self, mock_get_org_trials, mock_get_org_trials_count, mock_paginate, mock_compliance_counts):
         """Test processing organization dashboard request."""
         # Setup mocks
         org_ids = '1%2C2%2C3'  # URL encoded "1,2,3"
         
         org_trials = [{'nct_id': 'NCT001', 'status': 'Compliant'}]
-        mock_get_org_trials.return_value = org_trials
+        mock_get_org_trials.side_effect = [org_trials, org_trials]
+        mock_get_org_trials_count.return_value = 75
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = org_trials
@@ -223,8 +252,8 @@ class TestProcessOrganizationDashboardRequest:
         
         mock_compliance_counts.return_value = (1, 0)
         
-        # Call function
-        result = process_organization_dashboard_request(org_ids)
+        # Call function with explicit pagination parameters
+        result = process_organization_dashboard_request(org_ids, page=1, per_page=10)
         
         # Verify result
         expected = {
@@ -232,27 +261,32 @@ class TestProcessOrganizationDashboardRequest:
             'trials': org_trials,
             'pagination': mock_pagination,
             'per_page': 10,
-            'org_ids': '1,2,3',  # Should be decoded
+            'org_ids': '1,2,3',
             'on_time_count': 1,
             'late_count': 0
         }
         assert result == expected
         
-        # Verify mocks were called
-        mock_get_org_trials.assert_called_once_with((1, 2, 3))
-        mock_paginate.assert_called_once_with(org_trials)
+        # Verify mocks were called correctly
+        assert mock_get_org_trials.call_count == 2
+        mock_get_org_trials.assert_any_call((1, 2, 3), page=1, per_page=10)
+        mock_get_org_trials.assert_any_call((1, 2, 3))
+        mock_get_org_trials_count.assert_called_once_with((1, 2, 3))
+        mock_paginate.assert_called_once_with(org_trials, total_entries=75)
         mock_compliance_counts.assert_called_once_with(org_trials)
-    
+
     @patch('web.utils.route_helpers.compliance_counts')
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_org_trials_count')
     @patch('web.utils.route_helpers.get_org_trials')
-    def test_process_organization_dashboard_request_empty_org_ids(self, mock_get_org_trials, mock_paginate, mock_compliance_counts):
+    def test_process_organization_dashboard_request_empty_org_ids(self, mock_get_org_trials, mock_get_org_trials_count, mock_paginate, mock_compliance_counts):
         """Test processing organization dashboard request with empty org_ids."""
         # Setup mocks
         org_ids = ''
         
         org_trials = []
-        mock_get_org_trials.return_value = org_trials
+        mock_get_org_trials.side_effect = [org_trials, org_trials]
+        mock_get_org_trials_count.return_value = 0
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = []
@@ -260,27 +294,41 @@ class TestProcessOrganizationDashboardRequest:
         
         mock_compliance_counts.return_value = (0, 0)
         
-        # Call function
-        result = process_organization_dashboard_request(org_ids)
+        # Call function with explicit pagination parameters
+        result = process_organization_dashboard_request(org_ids, page=1, per_page=10)
         
         # Verify result
-        assert result['org_ids'] == ''
-        assert result['on_time_count'] == 0
-        assert result['late_count'] == 0
+        expected = {
+            'template': 'dashboards/organization.html',
+            'trials': [],
+            'pagination': mock_pagination,
+            'per_page': 10,
+            'org_ids': '',
+            'on_time_count': 0,
+            'late_count': 0
+        }
+        assert result == expected
         
-        # Verify mocks were called with empty tuple
-        mock_get_org_trials.assert_called_once_with(())
-    
+        # Verify mocks were called correctly
+        assert mock_get_org_trials.call_count == 2
+        mock_get_org_trials.assert_any_call((), page=1, per_page=10)
+        mock_get_org_trials.assert_any_call(())
+        mock_get_org_trials_count.assert_called_once_with(())
+        mock_paginate.assert_called_once_with([], total_entries=0)
+        mock_compliance_counts.assert_called_once_with([])
+
     @patch('web.utils.route_helpers.compliance_counts')
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_org_trials_count')
     @patch('web.utils.route_helpers.get_org_trials')
-    def test_process_organization_dashboard_request_single_org(self, mock_get_org_trials, mock_paginate, mock_compliance_counts):
+    def test_process_organization_dashboard_request_single_org(self, mock_get_org_trials, mock_get_org_trials_count, mock_paginate, mock_compliance_counts):
         """Test processing organization dashboard request with single organization."""
         # Setup mocks
         org_ids = '42'
         
         org_trials = [{'nct_id': 'NCT001', 'status': 'Compliant'}]
-        mock_get_org_trials.return_value = org_trials
+        mock_get_org_trials.side_effect = [org_trials, org_trials]
+        mock_get_org_trials_count.return_value = 30
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = org_trials
@@ -288,11 +336,28 @@ class TestProcessOrganizationDashboardRequest:
         
         mock_compliance_counts.return_value = (1, 0)
         
-        # Call function
-        result = process_organization_dashboard_request(org_ids)
+        # Call function with explicit pagination parameters
+        result = process_organization_dashboard_request(org_ids, page=1, per_page=10)
         
-        # Verify mocks were called with single-item tuple
-        mock_get_org_trials.assert_called_once_with((42,))
+        # Verify result
+        expected = {
+            'template': 'dashboards/organization.html',
+            'trials': org_trials,
+            'pagination': mock_pagination,
+            'per_page': 10,
+            'org_ids': '42',
+            'on_time_count': 1,
+            'late_count': 0
+        }
+        assert result == expected
+        
+        # Verify mocks were called correctly
+        assert mock_get_org_trials.call_count == 2
+        mock_get_org_trials.assert_any_call((42,), page=1, per_page=10)
+        mock_get_org_trials.assert_any_call((42,))
+        mock_get_org_trials_count.assert_called_once_with((42,))
+        mock_paginate.assert_called_once_with(org_trials, total_entries=30)
+        mock_compliance_counts.assert_called_once_with(org_trials)
 
 
 class TestParseRequestArg:
@@ -306,35 +371,36 @@ class TestParseRequestArg:
     
     def test_parse_request_arg_invalid_values(self):
         """Test parsing invalid values."""
-        assert parse_request_arg(None) is None
-        assert parse_request_arg('') is None
         assert parse_request_arg('abc') is None
+        assert parse_request_arg('') is None
+        assert parse_request_arg(None) is None
         assert parse_request_arg('12.5') is None
         assert parse_request_arg('-123') is None
-        assert parse_request_arg('1a2') is None
-        assert parse_request_arg(' 123 ') is None  # whitespace
+        assert parse_request_arg('123abc') is None
 
 
 class TestProcessCompareOrganizationsRequest:
     """Test the process_compare_organizations_request function."""
     
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_org_compliance_count')
     @patch('web.utils.route_helpers.get_org_compliance')
-    def test_process_compare_organizations_request_valid_params(self, mock_get_org_compliance, mock_paginate):
+    def test_process_compare_organizations_request_valid_params(self, mock_get_org_compliance, mock_get_org_compliance_count, mock_paginate):
         """Test processing compare organizations request with valid parameters."""
         # Setup mocks
         org_compliance = [
             {'id': 1, 'name': 'Org1', 'on_time_count': 5, 'late_count': 2},
             {'id': 2, 'name': 'Org2', 'on_time_count': 3, 'late_count': 1}
         ]
-        mock_get_org_compliance.return_value = org_compliance
+        mock_get_org_compliance.side_effect = [org_compliance, org_compliance]
+        mock_get_org_compliance_count.return_value = 20
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = org_compliance
         mock_paginate.return_value = (mock_pagination, 10)
         
-        # Call function with valid parameters
-        result = process_compare_organizations_request('80', '95', '5', '50')
+        # Call function with valid parameters and explicit pagination
+        result = process_compare_organizations_request('80', '95', '5', '50', page=1, per_page=10)
         
         # Verify result
         expected = {
@@ -348,87 +414,121 @@ class TestProcessCompareOrganizationsRequest:
         }
         assert result == expected
         
-        # Verify mocks were called with parsed parameters
-        mock_get_org_compliance.assert_called_once_with(
-            min_compliance=80,
-            max_compliance=95,
-            min_trials=5,
-            max_trials=50
-        )
-    
+        # Verify mocks were called correctly
+        assert mock_get_org_compliance.call_count == 2
+        mock_get_org_compliance.assert_any_call(min_compliance=80, max_compliance=95, min_trials=5, max_trials=50, page=1, per_page=10)
+        mock_get_org_compliance.assert_any_call(min_compliance=80, max_compliance=95, min_trials=5, max_trials=50)
+        mock_get_org_compliance_count.assert_called_once_with(min_compliance=80, max_compliance=95, min_trials=5, max_trials=50)
+        mock_paginate.assert_called_once_with(org_compliance, total_entries=20)
+
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_org_compliance_count')
     @patch('web.utils.route_helpers.get_org_compliance')
-    def test_process_compare_organizations_request_invalid_params(self, mock_get_org_compliance, mock_paginate):
+    def test_process_compare_organizations_request_invalid_params(self, mock_get_org_compliance, mock_get_org_compliance_count, mock_paginate):
         """Test processing compare organizations request with invalid parameters."""
         # Setup mocks
         org_compliance = []
-        mock_get_org_compliance.return_value = org_compliance
+        mock_get_org_compliance.side_effect = [org_compliance, org_compliance]
+        mock_get_org_compliance_count.return_value = 0
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = []
         mock_paginate.return_value = (mock_pagination, 10)
         
-        # Call function with invalid parameters
-        result = process_compare_organizations_request('invalid', '', 'not_a_number', None)
+        # Call function with invalid parameters and explicit pagination
+        result = process_compare_organizations_request('invalid', '', 'not_a_number', None, page=1, per_page=10)
         
         # Verify result
-        assert result['on_time_count'] == 0
-        assert result['late_count'] == 0
-        assert result['total_organizations'] == 0
+        expected = {
+            'template': 'dashboards/compare.html',
+            'org_compliance': [],
+            'pagination': mock_pagination,
+            'per_page': 10,
+            'on_time_count': 0,
+            'late_count': 0,
+            'total_organizations': 0
+        }
+        assert result == expected
         
-        # Verify mocks were called with None values
-        mock_get_org_compliance.assert_called_once_with(
-            min_compliance=None,
-            max_compliance=None,
-            min_trials=None,
-            max_trials=None
-        )
-    
+        # Verify mocks were called correctly
+        assert mock_get_org_compliance.call_count == 2
+        mock_get_org_compliance.assert_any_call(min_compliance=None, max_compliance=None, min_trials=None, max_trials=None, page=1, per_page=10)
+        mock_get_org_compliance.assert_any_call(min_compliance=None, max_compliance=None, min_trials=None, max_trials=None)
+        mock_get_org_compliance_count.assert_called_once_with(min_compliance=None, max_compliance=None, min_trials=None, max_trials=None)
+        mock_paginate.assert_called_once_with([], total_entries=0)
+
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_org_compliance_count')
     @patch('web.utils.route_helpers.get_org_compliance')
-    def test_process_compare_organizations_request_missing_counts(self, mock_get_org_compliance, mock_paginate):
+    def test_process_compare_organizations_request_missing_counts(self, mock_get_org_compliance, mock_get_org_compliance_count, mock_paginate):
         """Test processing compare organizations request with missing count fields."""
         # Setup mocks - organizations without count fields
         org_compliance = [
             {'id': 1, 'name': 'Org1'},  # Missing on_time_count, late_count
             {'id': 2, 'name': 'Org2', 'on_time_count': 5}  # Missing late_count
         ]
-        mock_get_org_compliance.return_value = org_compliance
+        mock_get_org_compliance.side_effect = [org_compliance, org_compliance]
+        mock_get_org_compliance_count.return_value = 15
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = org_compliance
         mock_paginate.return_value = (mock_pagination, 10)
         
-        # Call function
-        result = process_compare_organizations_request(None, None, None, None)
+        # Call function with explicit pagination
+        result = process_compare_organizations_request(None, None, None, None, page=1, per_page=10)
         
-        # Verify result - should handle missing fields gracefully
-        assert result['on_time_count'] == 5  # 0 + 5
-        assert result['late_count'] == 0     # 0 + 0
-        assert result['total_organizations'] == 2
-    
+        # Verify result
+        expected = {
+            'template': 'dashboards/compare.html',
+            'org_compliance': org_compliance,
+            'pagination': mock_pagination,
+            'per_page': 10,
+            'on_time_count': 5,  # 0 + 5
+            'late_count': 0,     # 0 + 0
+            'total_organizations': 2
+        }
+        assert result == expected
+        
+        # Verify mocks were called correctly
+        assert mock_get_org_compliance.call_count == 2
+        mock_get_org_compliance_count.assert_called_once_with(min_compliance=None, max_compliance=None, min_trials=None, max_trials=None)
+        mock_paginate.assert_called_once_with(org_compliance, total_entries=15)
+
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_org_compliance_count')
     @patch('web.utils.route_helpers.get_org_compliance')
-    def test_process_compare_organizations_request_zero_values(self, mock_get_org_compliance, mock_paginate):
+    def test_process_compare_organizations_request_zero_values(self, mock_get_org_compliance, mock_get_org_compliance_count, mock_paginate):
         """Test processing compare organizations request with zero parameter values."""
         # Setup mocks
         org_compliance = []
-        mock_get_org_compliance.return_value = org_compliance
+        mock_get_org_compliance.side_effect = [org_compliance, org_compliance]
+        mock_get_org_compliance_count.return_value = 0
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = []
         mock_paginate.return_value = (mock_pagination, 10)
         
-        # Call function with zero values (which should be valid)
-        result = process_compare_organizations_request('0', '0', '0', '0')
+        # Call function with zero values (which should be valid) and explicit pagination
+        result = process_compare_organizations_request('0', '0', '0', '0', page=1, per_page=10)
         
-        # Verify mocks were called with zero values
-        mock_get_org_compliance.assert_called_once_with(
-            min_compliance=0,
-            max_compliance=0,
-            min_trials=0,
-            max_trials=0
-        )
+        # Verify result
+        expected = {
+            'template': 'dashboards/compare.html',
+            'org_compliance': [],
+            'pagination': mock_pagination,
+            'per_page': 10,
+            'on_time_count': 0,
+            'late_count': 0,
+            'total_organizations': 0
+        }
+        assert result == expected
+        
+        # Verify mocks were called correctly
+        assert mock_get_org_compliance.call_count == 2
+        mock_get_org_compliance.assert_any_call(min_compliance=0, max_compliance=0, min_trials=0, max_trials=0, page=1, per_page=10)
+        mock_get_org_compliance.assert_any_call(min_compliance=0, max_compliance=0, min_trials=0, max_trials=0)
+        mock_get_org_compliance_count.assert_called_once_with(min_compliance=0, max_compliance=0, min_trials=0, max_trials=0)
+        mock_paginate.assert_called_once_with([], total_entries=0)
 
 
 class TestProcessUserDashboardRequest:
@@ -436,8 +536,9 @@ class TestProcessUserDashboardRequest:
     
     @patch('web.utils.route_helpers.compliance_counts')
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_user_trials_count')
     @patch('web.utils.route_helpers.get_user_trials')
-    def test_process_user_dashboard_request_with_trials(self, mock_get_user_trials, mock_paginate, mock_compliance_counts):
+    def test_process_user_dashboard_request_with_trials(self, mock_get_user_trials, mock_get_user_trials_count, mock_paginate, mock_compliance_counts):
         """Test processing user dashboard request with trials."""
         # Setup mocks
         user_id = 1
@@ -445,7 +546,8 @@ class TestProcessUserDashboardRequest:
             {'nct_id': 'NCT001', 'status': 'Compliant', 'email': 'user@example.com'},
             {'nct_id': 'NCT002', 'status': 'Incompliant', 'email': 'user@example.com'}
         ]
-        mock_get_user_trials.return_value = user_trials
+        mock_get_user_trials.side_effect = [user_trials, user_trials]
+        mock_get_user_trials_count.return_value = 40
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = user_trials
@@ -453,8 +555,8 @@ class TestProcessUserDashboardRequest:
         
         mock_compliance_counts.return_value = (1, 1)
         
-        # Call function
-        result = process_user_dashboard_request(user_id)
+        # Call function with explicit pagination parameters
+        result = process_user_dashboard_request(user_id, page=1, per_page=10)
         
         # Verify result
         expected = {
@@ -469,17 +571,22 @@ class TestProcessUserDashboardRequest:
         }
         assert result == expected
         
-        # Verify mocks were called
-        mock_get_user_trials.assert_called_once_with(user_id)
-        mock_paginate.assert_called_once_with(user_trials)
+        # Verify mocks were called correctly
+        assert mock_get_user_trials.call_count == 2
+        mock_get_user_trials.assert_any_call(user_id, page=1, per_page=10)
+        mock_get_user_trials.assert_any_call(user_id)
+        mock_get_user_trials_count.assert_called_once_with(user_id)
+        mock_paginate.assert_called_once_with(user_trials, total_entries=40)
         mock_compliance_counts.assert_called_once_with(user_trials)
-    
+
+    @patch('web.utils.route_helpers.get_user_trials_count')
     @patch('web.utils.route_helpers.get_user_trials')
-    def test_process_user_dashboard_request_no_trials_with_current_user(self, mock_get_user_trials):
+    def test_process_user_dashboard_request_no_trials_with_current_user(self, mock_get_user_trials, mock_get_user_trials_count):
         """Test processing user dashboard request with no trials and current user getter."""
         # Setup mocks
         user_id = 1
         mock_get_user_trials.return_value = []
+        mock_get_user_trials_count.return_value = 0
         
         # Mock current user getter
         mock_user = MagicMock()
@@ -487,51 +594,56 @@ class TestProcessUserDashboardRequest:
         def mock_current_user_getter(uid):
             return mock_user
         
-        # Call function
-        result = process_user_dashboard_request(user_id, mock_current_user_getter)
+        # Call function with explicit pagination parameters
+        result = process_user_dashboard_request(user_id, mock_current_user_getter, page=1, per_page=10)
         
         # Verify result
         expected = {
             'template': 'dashboards/user.html',
             'trials': [],
             'pagination': None,
-            'per_page': 25,
+            'per_page': 10,
             'user_id': user_id,
             'user_email': 'fallback@example.com'
         }
         assert result == expected
         
-        # Verify mocks were called
-        mock_get_user_trials.assert_called_once_with(user_id)
-    
+        # Verify mocks were called correctly
+        mock_get_user_trials.assert_called_once_with(user_id, page=1, per_page=10)
+        mock_get_user_trials_count.assert_called_once_with(user_id)
+
+    @patch('web.utils.route_helpers.get_user_trials_count')
     @patch('web.utils.route_helpers.get_user_trials')
-    def test_process_user_dashboard_request_no_trials_no_current_user(self, mock_get_user_trials):
+    def test_process_user_dashboard_request_no_trials_no_current_user(self, mock_get_user_trials, mock_get_user_trials_count):
         """Test processing user dashboard request with no trials and no current user getter."""
         # Setup mocks
         user_id = 1
         mock_get_user_trials.return_value = []
+        mock_get_user_trials_count.return_value = 0
         
-        # Call function without current user getter
-        result = process_user_dashboard_request(user_id)
+        # Call function without current user getter and with explicit pagination
+        result = process_user_dashboard_request(user_id, page=1, per_page=10)
         
         # Verify result
         expected = {
             'template': 'dashboards/user.html',
             'trials': [],
             'pagination': None,
-            'per_page': 25,
+            'per_page': 10,
             'user_id': user_id,
             'user_email': None
         }
         assert result == expected
         
-        # Verify mocks were called
-        mock_get_user_trials.assert_called_once_with(user_id)
-    
+        # Verify mocks were called correctly
+        mock_get_user_trials.assert_called_once_with(user_id, page=1, per_page=10)
+        mock_get_user_trials_count.assert_called_once_with(user_id)
+
     @patch('web.utils.route_helpers.compliance_counts')
     @patch('web.utils.route_helpers.paginate')
+    @patch('web.utils.route_helpers.get_user_trials_count')
     @patch('web.utils.route_helpers.get_user_trials')
-    def test_process_user_dashboard_request_mixed_status_trials(self, mock_get_user_trials, mock_paginate, mock_compliance_counts):
+    def test_process_user_dashboard_request_mixed_status_trials(self, mock_get_user_trials, mock_get_user_trials_count, mock_paginate, mock_compliance_counts):
         """Test processing user dashboard request with mixed status trials."""
         # Setup mocks
         user_id = 1
@@ -541,7 +653,8 @@ class TestProcessUserDashboardRequest:
             {'nct_id': 'NCT003', 'status': 'Unknown', 'email': 'user@example.com'},
             {'nct_id': 'NCT004', 'status': 'Pending', 'email': 'user@example.com'}
         ]
-        mock_get_user_trials.return_value = user_trials
+        mock_get_user_trials.side_effect = [user_trials, user_trials]
+        mock_get_user_trials_count.return_value = 60
         
         mock_pagination = MagicMock()
         mock_pagination.items_page = user_trials
@@ -550,27 +663,40 @@ class TestProcessUserDashboardRequest:
         # Only Compliant and Incompliant should count
         mock_compliance_counts.return_value = (1, 1)
         
-        # Call function
-        result = process_user_dashboard_request(user_id)
+        # Call function with explicit pagination parameters
+        result = process_user_dashboard_request(user_id, page=1, per_page=10)
         
         # Verify result
-        assert result['on_time_count'] == 1
-        assert result['late_count'] == 1
-        assert result['user_email'] == 'user@example.com'
+        expected = {
+            'template': 'dashboards/user.html',
+            'trials': user_trials,
+            'pagination': mock_pagination,
+            'per_page': 10,
+            'user_id': user_id,
+            'user_email': 'user@example.com',
+            'on_time_count': 1,
+            'late_count': 1
+        }
+        assert result == expected
         
-        # Verify mocks were called
-        mock_get_user_trials.assert_called_once_with(user_id)
+        # Verify mocks were called correctly
+        assert mock_get_user_trials.call_count == 2
+        mock_get_user_trials.assert_any_call(user_id, page=1, per_page=10)
+        mock_get_user_trials.assert_any_call(user_id)
+        mock_get_user_trials_count.assert_called_once_with(user_id)
+        mock_paginate.assert_called_once_with(user_trials, total_entries=60)
         mock_compliance_counts.assert_called_once_with(user_trials)
 
 
-# Additional edge case tests
 class TestEdgeCases:
-    """Test edge cases for route helper functions."""
+    """Test edge cases and error scenarios."""
     
+    @patch('web.utils.route_helpers.get_org_trials_count')
     @patch('web.utils.route_helpers.get_org_trials')
-    def test_organization_dashboard_with_comma_edge_cases(self, mock_get_org_trials):
+    def test_organization_dashboard_with_comma_edge_cases(self, mock_get_org_trials, mock_get_org_trials_count):
         """Test organization dashboard with various comma scenarios."""
         mock_get_org_trials.return_value = []
+        mock_get_org_trials_count.return_value = 0
         
         with patch('web.utils.route_helpers.paginate') as mock_paginate, \
              patch('web.utils.route_helpers.compliance_counts') as mock_compliance_counts:
@@ -580,37 +706,27 @@ class TestEdgeCases:
             mock_paginate.return_value = (mock_pagination, 10)
             mock_compliance_counts.return_value = (0, 0)
             
-            # Test with trailing/leading commas
-            result = process_organization_dashboard_request(',1,2,3,')
-            mock_get_org_trials.assert_called_with((1, 2, 3))
+            # Test with trailing/leading commas and explicit pagination
+            result = process_organization_dashboard_request(',1,2,3,', page=1, per_page=10)
             
-            # Test with multiple consecutive commas
-            result = process_organization_dashboard_request('1,,2,,3')
-            mock_get_org_trials.assert_called_with((1, 2, 3))
-    
+            # Should filter out empty strings and process only valid IDs
+            assert result['org_ids'] == ',1,2,3,'
+            assert result['template'] == 'dashboards/organization.html'
+            
+            # Verify that get_org_trials was called with the correct tuple (filtering empty strings)
+            mock_get_org_trials.assert_any_call((1, 2, 3), page=1, per_page=10)
+            mock_get_org_trials_count.assert_called_once_with((1, 2, 3))
+
     def test_search_request_edge_cases(self):
-        """Test search request with various edge cases."""
+        """Test search request with edge case parameters."""
         # Test with all None values
-        search_params = {key: None for key in ['title', 'nct_id', 'organization', 'user_email', 'date_type', 'date_from', 'date_to']}
+        search_params = {'title': None, 'nct_id': None, 'organization': None}
         compliance_status_list = []
         
-        result = process_search_request(search_params, compliance_status_list)
+        result = process_search_request(search_params, compliance_status_list, page=1, per_page=10)
         
-        # Should return template only
-        assert result == {'template': 'dashboards/home.html'}
-        
-        # Test with empty strings (should trigger search)
-        search_params['title'] = ''
-        with patch('web.utils.route_helpers.search_trials') as mock_search_trials:
-            mock_search_trials.return_value = []
-            with patch('web.utils.route_helpers.paginate') as mock_paginate, \
-                 patch('web.utils.route_helpers.compliance_counts') as mock_compliance_counts:
-                
-                mock_pagination = MagicMock()
-                mock_pagination.items_page = []
-                mock_paginate.return_value = (mock_pagination, 10)
-                mock_compliance_counts.return_value = (0, 0)
-                
-                # Empty string is falsy, so should not trigger search
-                result = process_search_request(search_params, compliance_status_list)
-                assert result == {'template': 'dashboards/home.html'} 
+        # Should return just the template since no search parameters
+        expected = {
+            'template': 'dashboards/home.html'
+        }
+        assert result == expected 

--- a/web/templates/sidebars/metrics_card.html
+++ b/web/templates/sidebars/metrics_card.html
@@ -5,7 +5,11 @@
             <div class="display-flex flex-justify-between margin-bottom-1">
                 <span class="font-sans-md">Compliance Rate</span>
                 <span class="usa-tag bg-primary text-white font-sans-md margin-left-auto metric-value">
-                    {{ ((on_time_count / (on_time_count + late_count)) * 100) | round(2) }}%
+                    {% if (on_time_count + late_count) > 0 %}
+                        {{ ((on_time_count / (on_time_count + late_count)) * 100) | round(2) }}%
+                    {% else %}
+                        0%
+                    {% endif %}
                 </span>
             </div>
             <div class="display-flex flex-justify-between margin-bottom-1">

--- a/web/utils/queries.py
+++ b/web/utils/queries.py
@@ -2,7 +2,21 @@ from web.db import query
 from flask import request
 
 
-def get_all_trials():
+def get_all_trials_count():
+    """Get total count of all trials"""
+    sql = '''
+    SELECT COUNT(*)
+    FROM trial t
+    LEFT JOIN trial_compliance tc ON t.id = tc.trial_id
+    LEFT JOIN organization o ON o.id = t.organization_id
+    LEFT JOIN ctgov_user u ON u.id = t.user_id
+    LEFT JOIN user_organization uo ON u.id = uo.user_id AND o.id = uo.organization_id
+    '''
+    result = query(sql)
+    return result[0]['count'] if result else 0
+
+
+def get_all_trials(page=None, per_page=None):
     sql = '''
     SELECT
         t.nct_id,
@@ -25,9 +39,31 @@ def get_all_trials():
     LEFT JOIN user_organization uo ON u.id = uo.user_id AND o.id = uo.organization_id
     ORDER BY t.title ASC
     '''
+    
+    # Add LIMIT and OFFSET if pagination parameters are provided
+    if page is not None and per_page is not None:
+        offset = (page - 1) * per_page
+        sql += f' LIMIT {per_page} OFFSET {offset}'
+    
     return query(sql)
 
-def get_org_trials(org_ids):
+
+def get_org_trials_count(org_ids):
+    """Get total count of trials for specific organizations"""
+    sql = '''
+    SELECT COUNT(*)
+    FROM trial t
+    LEFT JOIN trial_compliance tc ON t.id = tc.trial_id
+    LEFT JOIN organization o ON o.id = t.organization_id
+    LEFT JOIN ctgov_user u ON u.id = t.user_id
+    LEFT JOIN user_organization uo ON u.id = uo.user_id AND o.id = uo.organization_id
+    WHERE o.id IN %s
+    '''
+    result = query(sql, [org_ids])
+    return result[0]['count'] if result else 0
+
+
+def get_org_trials(org_ids, page=None, per_page=None):
     sql = '''
     SELECT 
         t.nct_id,
@@ -51,9 +87,31 @@ def get_org_trials(org_ids):
     WHERE o.id IN %s
     ORDER BY t.title ASC
     '''
+    
+    # Add LIMIT and OFFSET if pagination parameters are provided
+    if page is not None and per_page is not None:
+        offset = (page - 1) * per_page
+        sql += f' LIMIT {per_page} OFFSET {offset}'
+    
     return query(sql, [org_ids])
 
-def get_user_trials(user_id):
+
+def get_user_trials_count(user_id):
+    """Get total count of trials for a specific user"""
+    sql = '''
+    SELECT COUNT(*)
+    FROM trial t
+    LEFT JOIN trial_compliance tc ON t.id = tc.trial_id
+    LEFT JOIN organization o ON o.id = t.organization_id
+    LEFT JOIN ctgov_user u ON u.id = t.user_id
+    LEFT JOIN user_organization uo ON u.id = uo.user_id AND o.id = uo.organization_id
+    WHERE u.id = %s
+    '''
+    result = query(sql, [user_id])
+    return result[0]['count'] if result else 0
+
+
+def get_user_trials(user_id, page=None, per_page=None):
     sql = '''
     SELECT 
         t.nct_id,
@@ -77,9 +135,95 @@ def get_user_trials(user_id):
     WHERE u.id = %s
     ORDER BY t.title ASC
     '''
+    
+    # Add LIMIT and OFFSET if pagination parameters are provided
+    if page is not None and per_page is not None:
+        offset = (page - 1) * per_page
+        sql += f' LIMIT {per_page} OFFSET {offset}'
+    
     return query(sql, [user_id])
 
-def search_trials(params):
+
+def search_trials_count(params):
+    """Get total count of search results"""
+    base_sql = '''
+    SELECT COUNT(DISTINCT t.id)
+    FROM trial t
+    LEFT JOIN trial_compliance tc ON t.id = tc.trial_id
+    LEFT JOIN organization o ON o.id = t.organization_id
+    LEFT JOIN ctgov_user u ON u.id = t.user_id
+    LEFT JOIN user_organization uo ON u.id = uo.user_id AND o.id = uo.organization_id
+    WHERE 1=1
+    '''
+    
+    conditions = []
+    values = []
+    
+    if params.get('title'):
+        conditions.append("t.title ILIKE %s")
+        values.append(f"%{params['title']}%")
+        
+    if params.get('nct_id'):
+        conditions.append("t.nct_id ILIKE %s")
+        values.append(f"%{params['nct_id']}%")
+        
+    if params.get('organization'):
+        conditions.append("o.name ILIKE %s")
+        values.append(f"%{params['organization']}%")
+        
+    if params.get('status'):
+        conditions.append("t.status = %s")
+        values.append(params['status'])
+    
+    if params.get('user_email'):
+        conditions.append("u.email ILIKE %s")
+        values.append(f"%{params['user_email']}%")
+    
+    # Handle date range
+    date_type = params.get('date_type', 'completion')
+    date_from = params.get('date_from')
+    date_to = params.get('date_to')
+    
+    if date_from:
+        if date_type == 'completion':
+            conditions.append("t.completion_date >= %s")
+        elif date_type == 'start':
+            conditions.append("t.start_date >= %s")
+        elif date_type == 'due':
+            conditions.append("t.reporting_due_date >= %s")
+        values.append(date_from)
+    
+    if date_to:
+        if date_type == 'completion':
+            conditions.append("t.completion_date <= %s")
+        elif date_type == 'start':
+            conditions.append("t.start_date <= %s")
+        elif date_type == 'due':
+            conditions.append("t.reporting_due_date <= %s")
+        values.append(date_to)
+    
+    # Handle compliance status
+    compliance_status = request.args.getlist('compliance_status[]')
+    if compliance_status:
+        status_conditions = []
+        for status in compliance_status:
+            if status == 'compliant':
+                status_conditions.append("tc.status = 'Compliant'")
+            elif status == 'incompliant':
+                status_conditions.append("tc.status = 'Incompliant'")
+            elif status == 'pending':
+                status_conditions.append("tc.status IS NULL")
+        if status_conditions:
+            conditions.append(f"({' OR '.join(status_conditions)})")
+    
+    if conditions:
+        base_sql += " AND " + " AND ".join(conditions)
+    
+    result = query(base_sql, values)
+    return result[0]['count'] if result else 0
+
+
+def search_trials(params, page=None, per_page=None):
 
     
     base_sql = '''
@@ -170,9 +314,65 @@ def search_trials(params):
     
     base_sql += " ORDER BY t.title ASC"
     
+    # Add LIMIT and OFFSET if pagination parameters are provided
+    if page is not None and per_page is not None:
+        offset = (page - 1) * per_page
+        base_sql += f' LIMIT {per_page} OFFSET {offset}'
+    
     return query(base_sql, values)
 
-def get_org_compliance(min_compliance=None, max_compliance=None, min_trials=None, max_trials=None):
+
+def get_org_compliance_count(min_compliance=None, max_compliance=None, min_trials=None, max_trials=None):
+    """Get total count of organizations matching compliance criteria"""
+    sql = '''
+    SELECT COUNT(*)
+    FROM (
+        SELECT 
+            o.id,
+            o.name,
+            o.email_domain,
+            o.created_at,
+            COUNT(t.id) AS total_trials,
+            SUM(CASE WHEN tc.status = 'Compliant' THEN 1 ELSE 0 END) AS on_time_count,
+            SUM(CASE WHEN tc.status = 'Incompliant' THEN 1 ELSE 0 END) AS late_count,
+            -- Calculate reporting rate as percentage of trials with status
+            ROUND(
+                (COUNT(CASE WHEN tc.status IS NOT NULL THEN 1 END) * 100.0 / NULLIF(COUNT(t.id), 0)), 
+                1
+            ) AS reporting_rate,
+            -- Placeholder for funding source (would need additional table)
+            NULL AS funding_source,
+            -- Placeholder for Wilson LCB score (would need calculation)
+            NULL AS wilson_lcb_score
+        FROM organization o
+        LEFT JOIN trial t ON o.id = t.organization_id
+        LEFT JOIN trial_compliance tc ON t.id = tc.trial_id
+        GROUP BY o.id, o.name, o.email_domain, o.created_at
+    '''
+    having_clauses = []
+    params = []
+    # Compliance rate is calculated as (on_time_count / total_trials) * 100
+    if min_compliance is not None:
+        having_clauses.append('(SUM(CASE WHEN tc.status = \'Compliant\' THEN 1 ELSE 0 END) * 100.0 / NULLIF(COUNT(t.id),0)) >= %s')
+        params.append(min_compliance)
+    if max_compliance is not None:
+        having_clauses.append('(SUM(CASE WHEN tc.status = \'Compliant\' THEN 1 ELSE 0 END) * 100.0 / NULLIF(COUNT(t.id),0)) <= %s')
+        params.append(max_compliance)
+    if min_trials is not None:
+        having_clauses.append('COUNT(t.id) >= %s')
+        params.append(min_trials)
+    if max_trials is not None:
+        having_clauses.append('COUNT(t.id) <= %s')
+        params.append(max_trials)
+    if having_clauses:
+        sql += ' HAVING ' + ' AND '.join(having_clauses)
+    sql += '\n    ) AS subquery'
+    
+    result = query(sql, params)
+    return result[0]['count'] if result else 0
+
+
+def get_org_compliance(min_compliance=None, max_compliance=None, min_trials=None, max_trials=None, page=None, per_page=None):
     sql = '''
     SELECT 
         o.id,
@@ -214,6 +414,12 @@ def get_org_compliance(min_compliance=None, max_compliance=None, min_trials=None
     if having_clauses:
         sql += ' HAVING ' + ' AND '.join(having_clauses)
     sql += '\nORDER BY total_trials DESC, o.name ASC'
+    
+    # Add LIMIT and OFFSET if pagination parameters are provided
+    if page is not None and per_page is not None:
+        offset = (page - 1) * per_page
+        sql += f' LIMIT {per_page} OFFSET {offset}'
+    
     return query(sql, params)
 
 

--- a/web/utils/route_helpers.py
+++ b/web/utils/route_helpers.py
@@ -6,8 +6,14 @@ without Flask context dependencies while maintaining clean separation of concern
 """
 
 from urllib.parse import unquote
-from .queries import get_all_trials, get_org_trials, get_org_compliance, get_user_trials, search_trials
-from .pagination import paginate
+from .queries import (
+    get_all_trials, get_all_trials_count,
+    get_org_trials, get_org_trials_count,
+    get_org_compliance, get_org_compliance_count,
+    get_user_trials, get_user_trials_count,
+    search_trials, search_trials_count
+)
+from .pagination import paginate, get_pagination_args
 
 
 def compliance_counts(trials):
@@ -26,12 +32,22 @@ def compliance_counts(trials):
     return on_time_count, late_count
 
 
-def process_index_request():
+def process_index_request(page=None, per_page=None):
     """Process the index page request and return template data."""
-    trials = get_all_trials()
-    pagination, per_page = paginate(trials)
+    # Get pagination parameters from request if not provided
+    if page is None or per_page is None:
+        page, per_page = get_pagination_args()
     
-    on_time_count, late_count = compliance_counts(trials)
+    # Get paginated trials and total count
+    trials = get_all_trials(page=page, per_page=per_page)
+    total_count = get_all_trials_count()
+    
+    # Get all trials for compliance counts (we need the full dataset for this)
+    all_trials = get_all_trials()
+    
+    pagination, per_page = paginate(trials, total_entries=total_count)
+    
+    on_time_count, late_count = compliance_counts(all_trials)
     
     return {
         'template': 'dashboards/home.html',
@@ -43,14 +59,24 @@ def process_index_request():
     }
 
 
-def process_search_request(search_params, compliance_status_list):
+def process_search_request(search_params, compliance_status_list, page=None, per_page=None):
     """Process a search request and return template data."""
     # If there are any search parameters, perform the search
     if any(search_params.values()) or compliance_status_list:
-        search_results = search_trials(search_params)
-        pagination, per_page = paginate(search_results)
+        # Get pagination parameters from request if not provided
+        if page is None or per_page is None:
+            page, per_page = get_pagination_args()
         
-        on_time_count, late_count = compliance_counts(search_results)
+        # Get paginated search results and total count
+        search_results = search_trials(search_params, page=page, per_page=per_page)
+        total_count = search_trials_count(search_params)
+        
+        # Get all search results for compliance counts
+        all_search_results = search_trials(search_params)
+        
+        pagination, per_page = paginate(search_results, total_entries=total_count)
+        
+        on_time_count, late_count = compliance_counts(all_search_results)
         
         return {
             'template': 'dashboards/home.html',
@@ -68,15 +94,26 @@ def process_search_request(search_params, compliance_status_list):
     }
 
 
-def process_organization_dashboard_request(org_ids):
+def process_organization_dashboard_request(org_ids, page=None, per_page=None):
     """Process organization dashboard request and return template data."""
     # Convert org_ids to a tuple of integers
     decoded_org_ids = unquote(unquote(org_ids))
     org_list = tuple(int(id) for id in decoded_org_ids.split(',') if id)
-    org_trials = get_org_trials(org_list)
-    pagination, per_page = paginate(org_trials)
     
-    on_time_count, late_count = compliance_counts(org_trials)
+    # Get pagination parameters from request if not provided
+    if page is None or per_page is None:
+        page, per_page = get_pagination_args()
+    
+    # Get paginated organization trials and total count
+    org_trials = get_org_trials(org_list, page=page, per_page=per_page)
+    total_count = get_org_trials_count(org_list)
+    
+    # Get all organization trials for compliance counts
+    all_org_trials = get_org_trials(org_list)
+    
+    pagination, per_page = paginate(org_trials, total_entries=total_count)
+    
+    on_time_count, late_count = compliance_counts(all_org_trials)
 
     return {
         'template': 'dashboards/organization.html',
@@ -94,7 +131,7 @@ def parse_request_arg(val):
     return int(val) if val and val.isdigit() else None
 
 
-def process_compare_organizations_request(min_compliance, max_compliance, min_trials, max_trials):
+def process_compare_organizations_request(min_compliance, max_compliance, min_trials, max_trials, page=None, per_page=None):
     """Process compare organizations request and return template data."""
     # Parse arguments
     parsed_min_compliance = parse_request_arg(min_compliance)
@@ -102,17 +139,39 @@ def process_compare_organizations_request(min_compliance, max_compliance, min_tr
     parsed_min_trials = parse_request_arg(min_trials)
     parsed_max_trials = parse_request_arg(max_trials)
 
+    # Get pagination parameters from request if not provided
+    if page is None or per_page is None:
+        page, per_page = get_pagination_args()
+    
+    # Get paginated organization compliance and total count
     org_compliance = get_org_compliance(
+        min_compliance=parsed_min_compliance,
+        max_compliance=parsed_max_compliance,
+        min_trials=parsed_min_trials,
+        max_trials=parsed_max_trials,
+        page=page,
+        per_page=per_page
+    )
+    total_count = get_org_compliance_count(
         min_compliance=parsed_min_compliance,
         max_compliance=parsed_max_compliance,
         min_trials=parsed_min_trials,
         max_trials=parsed_max_trials
     )
-    pagination, per_page = paginate(org_compliance)
+    
+    # Get all organization compliance for summary counts
+    all_org_compliance = get_org_compliance(
+        min_compliance=parsed_min_compliance,
+        max_compliance=parsed_max_compliance,
+        min_trials=parsed_min_trials,
+        max_trials=parsed_max_trials
+    )
+    
+    pagination, per_page = paginate(org_compliance, total_entries=total_count)
 
-    on_time_count = sum(org.get('on_time_count', 0) for org in org_compliance)
-    late_count = sum(org.get('late_count', 0) for org in org_compliance)
-    total_organizations = len(org_compliance)
+    on_time_count = sum(org.get('on_time_count', 0) for org in all_org_compliance)
+    late_count = sum(org.get('late_count', 0) for org in all_org_compliance)
+    total_organizations = len(all_org_compliance)
 
     return {
         'template': 'dashboards/compare.html',
@@ -125,14 +184,25 @@ def process_compare_organizations_request(min_compliance, max_compliance, min_tr
     }
 
 
-def process_user_dashboard_request(user_id, current_user_getter=None):
+def process_user_dashboard_request(user_id, current_user_getter=None, page=None, per_page=None):
     """Process user dashboard request and return template data."""
-    user_trials = get_user_trials(user_id)
+    # Get pagination parameters from request if not provided
+    if page is None or per_page is None:
+        page, per_page = get_pagination_args()
+    
+    # Get paginated user trials and total count
+    user_trials = get_user_trials(user_id, page=page, per_page=per_page)
+    total_count = get_user_trials_count(user_id)
+    
     if user_trials:
         user_email = user_trials[0]['email']
-        pagination, per_page = paginate(user_trials)
+        
+        # Get all user trials for compliance counts
+        all_user_trials = get_user_trials(user_id)
+        
+        pagination, per_page = paginate(user_trials, total_entries=total_count)
 
-        on_time_count, late_count = compliance_counts(user_trials)
+        on_time_count, late_count = compliance_counts(all_user_trials)
 
         return {
             'template': 'dashboards/user.html',
@@ -151,7 +221,7 @@ def process_user_dashboard_request(user_id, current_user_getter=None):
             'template': 'dashboards/user.html',
             'trials': [],
             'pagination': None,
-            'per_page': 25,
+            'per_page': per_page if per_page is not None else 25,
             'user_id': user_id,
             'user_email': user_email
         } 


### PR DESCRIPTION
- Replace post-query Python slicing with SQL LIMIT/OFFSET for better performance
- Add count queries for all data fetching functions (get_all_trials_count, get_org_trials_count, etc.)
- Modify data queries to accept page/per_page parameters and use SQL pagination
- Update Pagination class to work with total count instead of full result set
- Update route helpers to use new pagination approach while maintaining backwards compatibility
- Update tests to work with new implementation and add backwards compatibility test cases

This change improves performance by handling pagination at the database level instead of fetching all data and filtering in Python, making the application more scalable for large datasets.